### PR TITLE
Add Swagger documentation

### DIFF
--- a/src/modules/analytics/analytics.controller.ts
+++ b/src/modules/analytics/analytics.controller.ts
@@ -1,11 +1,23 @@
 import { Controller, Get, Query } from '@nestjs/common';
 import { AnalyticsService } from './analytics.service';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiQuery,
+  ApiOkResponse,
+} from '@nestjs/swagger';
 
+@ApiTags('Analytics')
 @Controller('analytics')
 export class AnalyticsController {
   constructor(private readonly analyticsService: AnalyticsService) {}
 
   @Get('session-count')
+  @ApiOperation({ summary: 'عدد الجلسات خلال فترة' })
+  @ApiQuery({ name: 'merchantId', description: 'معرّف التاجر' })
+  @ApiQuery({ name: 'from', description: 'بداية الفترة', type: String })
+  @ApiQuery({ name: 'to', description: 'نهاية الفترة', type: String })
+  @ApiOkResponse({ description: 'إحصائية عدد الجلسات' })
   async getSessionCount(
     @Query('merchantId') merchantId: string,
     @Query('from') from: string,
@@ -23,11 +35,18 @@ export class AnalyticsController {
     return { merchantId, count, from: fromDate, to: toDate };
   }
   @Get('message-role-stats')
+  @ApiOperation({ summary: 'إحصائية عدد الرسائل حسب الدور' })
+  @ApiQuery({ name: 'merchantId', description: 'معرّف التاجر' })
+  @ApiOkResponse()
   async getMessageRoleStats(@Query('merchantId') merchantId: string) {
     const stats = await this.analyticsService.countMessagesByRole(merchantId);
     return stats;
   }
   @Get('top-questions')
+  @ApiOperation({ summary: 'أكثر الأسئلة تكرارًا من العملاء' })
+  @ApiQuery({ name: 'merchantId', description: 'معرّف التاجر' })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiOkResponse()
   async getTopQuestions(
     @Query('merchantId') merchantId: string,
     @Query('limit') limit?: string,
@@ -38,6 +57,11 @@ export class AnalyticsController {
     );
   }
   @Get('daily-sessions')
+  @ApiOperation({ summary: 'عدد الجلسات يوميًا' })
+  @ApiQuery({ name: 'merchantId', description: 'معرّف التاجر' })
+  @ApiQuery({ name: 'from', description: 'بداية الفترة', type: String })
+  @ApiQuery({ name: 'to', description: 'نهاية الفترة', type: String })
+  @ApiOkResponse()
   async getDailySessions(
     @Query('merchantId') merchantId: string,
     @Query('from') from: string,
@@ -50,10 +74,17 @@ export class AnalyticsController {
     );
   }
   @Get('channel-usage')
+  @ApiOperation({ summary: 'توزيع استخدام القنوات' })
+  @ApiQuery({ name: 'merchantId', description: 'معرّف التاجر' })
+  @ApiOkResponse()
   async getChannelUsage(@Query('merchantId') merchantId: string) {
     return this.analyticsService.channelDistribution(merchantId);
   }
   @Get('top-products-requested')
+  @ApiOperation({ summary: 'أكثر المنتجات طلبًا' })
+  @ApiQuery({ name: 'merchantId', description: 'معرّف التاجر' })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiOkResponse()
   async getTopRequestedProducts(
     @Query('merchantId') merchantId: string,
     @Query('limit') limit?: string,
@@ -64,6 +95,10 @@ export class AnalyticsController {
     );
   }
   @Get('top-keywords')
+  @ApiOperation({ summary: 'أكثر الكلمات استخدامًا من العملاء' })
+  @ApiQuery({ name: 'merchantId', description: 'معرّف التاجر' })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiOkResponse()
   async getTopKeywords(
     @Query('merchantId') merchantId: string,
     @Query('limit') limit?: string,

--- a/src/modules/documents/documents.controller.ts
+++ b/src/modules/documents/documents.controller.ts
@@ -11,16 +11,31 @@ import {
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiBody,
+  ApiOkResponse,
+  ApiNoContentResponse,
+} from '@nestjs/swagger';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { Response } from 'express';
 import { DocumentsService } from './documents.service';
 
+@ApiTags('Documents')
+@ApiBearerAuth()
 @Controller('merchants/:merchantId/documents')
 export class DocumentsController {
   constructor(private readonly svc: DocumentsService) {}
 
   @Post()
   @UseInterceptors(FileInterceptor('file'))
+  @ApiOperation({ summary: 'رفع مستند للتاجر' })
+  @ApiParam({ name: 'merchantId', description: 'معرف التاجر' })
+  @ApiBody({ type: 'string', format: 'binary', name: 'file' })
+  @ApiOkResponse({ description: 'تم رفع الملف' })
   upload(
     @Param('merchantId') merchantId: string,
     @UploadedFile() file: Express.Multer.File & { key: string },
@@ -30,11 +45,17 @@ export class DocumentsController {
   }
 
   @Get()
+  @ApiOperation({ summary: 'قائمة ملفات التاجر' })
+  @ApiParam({ name: 'merchantId', description: 'معرف التاجر' })
+  @ApiOkResponse()
   list(@Param('merchantId') merchantId: string) {
     return this.svc.list(merchantId);
   }
 
   @Get(':docId')
+  @ApiOperation({ summary: 'تنزيل ملف' })
+  @ApiParam({ name: 'merchantId', description: 'معرف التاجر' })
+  @ApiParam({ name: 'docId', description: 'معرف المستند' })
   async download(
     @Param('merchantId') merchantId: string,
     @Param('docId') docId: string,
@@ -47,6 +68,10 @@ export class DocumentsController {
 
   @Delete(':docId')
   @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'حذف مستند' })
+  @ApiParam({ name: 'merchantId', description: 'معرف التاجر' })
+  @ApiParam({ name: 'docId', description: 'معرف المستند' })
+  @ApiNoContentResponse()
   remove(
     @Param('merchantId') merchantId: string,
     @Param('docId') docId: string,

--- a/src/modules/merchants/dto/address.dto.ts
+++ b/src/modules/merchants/dto/address.dto.ts
@@ -1,10 +1,11 @@
 // src/merchants/dto/address.dto.ts
 import { IsString } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class AddressDto {
-  @IsString() street: string;
-  @IsString() city: string;
-  @IsString() country: string;
-  @IsString() state?: string;
-  @IsString() postalCode?: string;
+  @ApiProperty() @IsString() street: string;
+  @ApiProperty() @IsString() city: string;
+  @ApiProperty() @IsString() country: string;
+  @ApiPropertyOptional() @IsString() state?: string;
+  @ApiPropertyOptional() @IsString() postalCode?: string;
 }

--- a/src/modules/merchants/dto/channel.dto.ts
+++ b/src/modules/merchants/dto/channel.dto.ts
@@ -7,30 +7,34 @@ import {
   IsObject,
   ValidateNested,
 } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 
 /** تفاصيل قناة واحدة (واتساب/تيليجرام/ويبشات) */
 export class ChannelDetailsDto {
-  @IsOptional() @IsBoolean() enabled?: boolean;
-  @IsOptional() @IsString() phone?: string;
-  @IsOptional() @IsString() token?: string;
-  @IsOptional() @IsString() chatId?: string;
-  @IsOptional() @IsString() webhookUrl?: string;
-  @IsOptional() @IsObject() widgetSettings?: Record<string, any>;
+  @ApiPropertyOptional() @IsOptional() @IsBoolean() enabled?: boolean;
+  @ApiPropertyOptional() @IsOptional() @IsString() phone?: string;
+  @ApiPropertyOptional() @IsOptional() @IsString() token?: string;
+  @ApiPropertyOptional() @IsOptional() @IsString() chatId?: string;
+  @ApiPropertyOptional() @IsOptional() @IsString() webhookUrl?: string;
+  @ApiPropertyOptional() @IsOptional() @IsObject() widgetSettings?: Record<string, any>;
   /** رابط الويبهوك (اختياري) */
 }
 
 /** مجموعة القنوات كلها */
 export class ChannelsDto {
+  @ApiPropertyOptional()
   @IsOptional()
   @ValidateNested()
   @Type(() => ChannelDetailsDto)
   whatsapp?: ChannelDetailsDto;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @ValidateNested()
   @Type(() => ChannelDetailsDto)
   telegram?: ChannelDetailsDto;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @ValidateNested()
   @Type(() => ChannelDetailsDto)

--- a/src/modules/merchants/dto/create-merchant.dto.ts
+++ b/src/modules/merchants/dto/create-merchant.dto.ts
@@ -9,6 +9,7 @@ import {
   ArrayNotEmpty,
   ValidateNested,
 } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 import { AddressDto } from './address.dto';
 import { SubscriptionPlanDto } from './subscription-plan.dto';
@@ -18,85 +19,104 @@ import { WorkingHourDto } from './working-hours.dto';
 import { AdvancedTemplateDto } from './advanced-template.dto';
 
 export class CreateMerchantDto {
+  @ApiProperty()
   @IsString()
   name: string;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsUrl()
   storefrontUrl?: string;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsUrl()
   logoUrl?: string;
 
   // أضفنا العنوان هنا
+  @ApiPropertyOptional({ type: AddressDto })
   @IsOptional()
   @ValidateNested()
   @Type(() => AddressDto)
   address?: AddressDto;
 
+  @ApiProperty({ type: SubscriptionPlanDto })
   @ValidateNested()
   @Type(() => SubscriptionPlanDto)
   subscription: SubscriptionPlanDto;
 
+  @ApiPropertyOptional({ type: [String] })
   @IsOptional()
   @IsArray()
   @ArrayNotEmpty()
   @IsString({ each: true })
   categories?: string[];
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsString()
   domain?: string;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsString()
   phone?: string;
+  @ApiPropertyOptional()
   @IsOptional()
   @IsString()
   businessType?: string;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsString()
   businessDescription?: string;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsString()
   workflowId?: string;
 
+  @ApiPropertyOptional({ type: QuickConfigDto })
   @IsOptional()
   @ValidateNested()
   @Type(() => QuickConfigDto)
   quickConfig?: QuickConfigDto;
 
+  @ApiPropertyOptional({ type: AdvancedTemplateDto })
   @IsOptional()
   @ValidateNested()
   @Type(() => AdvancedTemplateDto)
   currentAdvancedConfig?: AdvancedTemplateDto;
 
+  @ApiPropertyOptional({ type: [AdvancedTemplateDto] })
   @IsOptional()
   @ValidateNested({ each: true })
   @Type(() => AdvancedTemplateDto)
   advancedConfigHistory?: AdvancedTemplateDto[];
 
+  @ApiPropertyOptional({ type: ChannelsDto })
   @IsOptional()
   @ValidateNested()
   @Type(() => ChannelsDto)
   channels?: ChannelsDto;
 
+  @ApiPropertyOptional({ type: [WorkingHourDto] })
   @IsOptional()
   @ValidateNested({ each: true })
   @Type(() => WorkingHourDto)
   workingHours?: WorkingHourDto[];
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsString()
   returnPolicy?: string;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsString()
   exchangePolicy?: string;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsString()
   shippingPolicy?: string;

--- a/src/modules/merchants/dto/onboarding.dto.ts
+++ b/src/modules/merchants/dto/onboarding.dto.ts
@@ -2,47 +2,56 @@
 
 import { Type } from 'class-transformer';
 import { IsString, IsOptional, IsUrl, ValidateNested } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { AddressDto } from './address.dto';
 import { SubscriptionPlanDto } from './subscription-plan.dto';
 import { ChannelsDto } from './channel.dto';
 
 export class OnboardingDto {
   /** اسم المتجر */
+  @ApiProperty()
   @IsString()
   name: string;
 
   /** رابط واجهة المتجر (اختياري) */
+  @ApiPropertyOptional()
   @IsOptional()
   @IsUrl()
   storeUrl?: string;
 
   /** رابط شعار المتجر (اختياري) */
+  @ApiPropertyOptional()
   @IsOptional()
   @IsUrl()
   logoUrl?: string;
 
   /** عنوان المتجر (اختياري) */
+  @ApiPropertyOptional({ type: AddressDto })
   @IsOptional()
   @ValidateNested()
   @Type(() => AddressDto)
   address?: AddressDto;
 
   /** باقة الاشتراك */
+  @ApiProperty({ type: SubscriptionPlanDto })
   @ValidateNested()
   @Type(() => SubscriptionPlanDto)
   subscription: SubscriptionPlanDto;
 
   /** نوع العمل (اختياري) */
+  @ApiPropertyOptional()
   @IsOptional()
   @IsString()
   businessType?: string;
 
   /** وصف العمل (اختياري) */
+  @ApiPropertyOptional()
   @IsOptional()
   @IsString()
   businessDescription?: string;
 
   /** إعدادات القنوات (اختياري) */
+  @ApiPropertyOptional({ type: ChannelsDto })
   @IsOptional()
   @ValidateNested()
   @Type(() => ChannelsDto)

--- a/src/modules/merchants/dto/preview-prompt.dto.ts
+++ b/src/modules/merchants/dto/preview-prompt.dto.ts
@@ -8,16 +8,20 @@ import {
   IsOptional,
   ValidateNested,
 } from 'class-validator';
+import { ApiPropertyOptional, ApiProperty } from '@nestjs/swagger';
 
 export class PreviewPromptDto {
+  @ApiPropertyOptional({ type: QuickConfigDto })
   @IsOptional()
   @ValidateNested()
   @Type(() => QuickConfigDto)
   quickConfig?: Partial<QuickConfigDto>; // الآن اختياري وجزئي
 
+  @ApiProperty()
   @IsBoolean()
   useAdvanced: boolean;
 
+  @ApiProperty({ type: Object })
   @IsObject()
   testVars: Record<string, string>;
 }

--- a/src/modules/merchants/dto/subscription-plan.dto.ts
+++ b/src/modules/merchants/dto/subscription-plan.dto.ts
@@ -7,14 +7,17 @@ import {
   ArrayNotEmpty,
   IsString,
 } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { PlanTier } from '../schemas/subscription-plan.schema';
 
 export class SubscriptionPlanDto {
+  @ApiProperty({ enum: PlanTier })
   @IsEnum(PlanTier) tier: PlanTier;
 
-  @IsDateString() startDate: string;
-  @IsOptional() @IsDateString() endDate?: string;
+  @ApiProperty() @IsDateString() startDate: string;
+  @ApiPropertyOptional() @IsDateString() endDate?: string;
 
+  @ApiProperty({ type: [String] })
   @IsArray()
   @ArrayNotEmpty()
   @IsString({ each: true })

--- a/src/modules/merchants/dto/working-hours.dto.ts
+++ b/src/modules/merchants/dto/working-hours.dto.ts
@@ -1,16 +1,20 @@
 import { IsEnum, IsString, Matches } from 'class-validator';
 import { WeekDay } from '../schemas/working-hours.schema';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class WorkingHourDto {
+  @ApiProperty({ enum: WeekDay })
   @IsEnum(WeekDay)
   day: WeekDay;
 
+  @ApiProperty({ description: 'وقت الفتح بصيغة HH:mm' })
   @IsString()
   @Matches(/^\d{2}:\d{2}$/, {
     message: 'openTime must be in HH:mm format',
   })
   openTime: string;
 
+  @ApiProperty({ description: 'وقت الإغلاق بصيغة HH:mm' })
   @IsString()
   @Matches(/^\d{2}:\d{2}$/, {
     message: 'closeTime must be in HH:mm format',

--- a/src/modules/messaging/chat-links.controller.ts
+++ b/src/modules/messaging/chat-links.controller.ts
@@ -2,12 +2,22 @@
 import { Controller, Post, Param } from '@nestjs/common';
 import { MessageService } from './message.service';
 import { v4 as uuidv4 } from 'uuid';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiParam,
+  ApiCreatedResponse,
+} from '@nestjs/swagger';
 
+@ApiTags('Chat Links')
 @Controller('chat-links')
 export class ChatLinksController {
   constructor(private readonly messageService: MessageService) {}
 
   @Post(':merchantId')
+  @ApiOperation({ summary: 'إنشاء رابط محادثة مؤقت' })
+  @ApiParam({ name: 'merchantId', description: 'معرف التاجر' })
+  @ApiCreatedResponse({ description: 'تم إنشاء الرابط' })
   async createChatLink(@Param('merchantId') merchantId: string) {
     // توليد sessionId جديد
     const sessionId = uuidv4();

--- a/src/modules/messaging/message.controller.ts
+++ b/src/modules/messaging/message.controller.ts
@@ -20,8 +20,10 @@ import {
   ApiOperation,
   ApiParam,
   ApiQuery,
+  ApiTags,
 } from '@nestjs/swagger';
 
+@ApiTags('Messages')
 @Controller('messages')
 export class MessageController {
   constructor(private readonly messageService: MessageService) {}

--- a/src/modules/n8n-workflow/dto/update-workflow.dto.ts
+++ b/src/modules/n8n-workflow/dto/update-workflow.dto.ts
@@ -2,8 +2,10 @@
 
 import { IsObject } from 'class-validator';
 import { WorkflowDefinition } from '../n8n-workflow.service';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class UpdateWorkflowDto {
+  @ApiProperty({ type: Object, description: 'التعديلات على JSON الخاص بالورك فلو' })
   @IsObject()
   jsonPatch: Partial<WorkflowDefinition>;
 }

--- a/src/modules/n8n-workflow/n8n-workflow.controller.ts
+++ b/src/modules/n8n-workflow/n8n-workflow.controller.ts
@@ -8,6 +8,15 @@ import {
   Body,
   UseGuards,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiBody,
+  ApiOkResponse,
+  ApiCreatedResponse,
+} from '@nestjs/swagger';
 import { N8nWorkflowService, WorkflowDefinition } from './n8n-workflow.service';
 import { RolesGuard } from '../../common/guards/roles.guard';
 import { Roles } from '../../common/decorators/roles.decorator';
@@ -17,6 +26,8 @@ import { RollbackDto } from './dto/rollback.dto';
 import { SetActiveDto } from './dto/set-active.dto';
 import { JwtAuthGuard } from 'src/common/guards/jwt-auth.guard';
 
+@ApiTags('n8n Workflows')
+@ApiBearerAuth()
 @UseGuards(JwtAuthGuard, RolesGuard)
 @Controller('n8n/workflows')
 export class N8nWorkflowController {
@@ -24,6 +35,9 @@ export class N8nWorkflowController {
 
   @Post(':merchantId')
   @Roles('ADMIN', 'MEMBER')
+  @ApiOperation({ summary: 'إنشاء ورك فلو لتاجر' })
+  @ApiParam({ name: 'merchantId', description: 'معرف التاجر' })
+  @ApiCreatedResponse({ description: 'تم إنشاء الورك فلو' })
   async createForMerchant(
     @Param('merchantId') merchantId: string,
   ): Promise<{ workflowId: string }> {
@@ -38,6 +52,9 @@ export class N8nWorkflowController {
 
   @Get(':workflowId')
   @Roles('ADMIN', 'MEMBER')
+  @ApiOperation({ summary: 'جلب تعريف ورك فلو' })
+  @ApiParam({ name: 'workflowId', description: 'معرف الورك فلو' })
+  @ApiOkResponse()
   async get(
     @Param('workflowId') workflowId: string,
   ): Promise<WorkflowDefinition> {
@@ -46,6 +63,10 @@ export class N8nWorkflowController {
 
   @Patch(':workflowId')
   @Roles('ADMIN')
+  @ApiOperation({ summary: 'تحديث ورك فلو' })
+  @ApiParam({ name: 'workflowId', description: 'معرف الورك فلو' })
+  @ApiBody({ type: UpdateWorkflowDto })
+  @ApiOkResponse({ description: 'تم التحديث' })
   async update(
     @Param('workflowId') workflowId: string,
     @Body() body: UpdateWorkflowDto,
@@ -64,6 +85,10 @@ export class N8nWorkflowController {
 
   @Post(':workflowId/rollback')
   @Roles('ADMIN')
+  @ApiOperation({ summary: 'الرجوع لنسخة سابقة' })
+  @ApiParam({ name: 'workflowId', description: 'معرف الورك فلو' })
+  @ApiBody({ type: RollbackDto })
+  @ApiOkResponse({ description: 'تم الرجوع بنجاح' })
   async rollback(
     @Param('workflowId') workflowId: string,
     @Body() dto: RollbackDto,
@@ -74,6 +99,10 @@ export class N8nWorkflowController {
 
   @Post(':workflowId/clone/:targetMerchantId')
   @Roles('ADMIN')
+  @ApiOperation({ summary: 'نسخ ورك فلو لتاجر آخر' })
+  @ApiParam({ name: 'workflowId', description: 'معرف الورك فلو' })
+  @ApiParam({ name: 'targetMerchantId', description: 'التاجر الهدف' })
+  @ApiOkResponse({ description: 'تم النسخ' })
   async clone(
     @Param('workflowId') sourceId: string,
     @Param('targetMerchantId') targetMerchantId: string,
@@ -88,6 +117,10 @@ export class N8nWorkflowController {
 
   @Patch(':workflowId/active')
   @Roles('ADMIN')
+  @ApiOperation({ summary: 'تفعيل أو تعطيل ورك فلو' })
+  @ApiParam({ name: 'workflowId', description: 'معرف الورك فلو' })
+  @ApiBody({ type: SetActiveDto })
+  @ApiOkResponse()
   async setActive(
     @Param('workflowId') workflowId: string,
     @Body() dto: SetActiveDto,

--- a/src/modules/vector/dto/semantic-request.dto.ts
+++ b/src/modules/vector/dto/semantic-request.dto.ts
@@ -1,15 +1,19 @@
 import { Type } from 'class-transformer';
 import { IsString, IsNotEmpty, IsOptional, IsNumber } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class SemanticRequestDto {
+  @ApiProperty({ description: 'النص المطلوب البحث عنه' })
   @IsString()
   @IsNotEmpty()
   text: string;
 
+  @ApiProperty({ description: 'معرّف التاجر' })
   @IsString()
   @IsNotEmpty()
   merchantId: string;
 
+  @ApiPropertyOptional({ description: 'عدد النتائج المطلوبة', default: 5 })
   @IsOptional()
   @Type(() => Number) // ← هذا يحل المشكلة
   @IsNumber()

--- a/src/modules/vector/vector.controller.ts
+++ b/src/modules/vector/vector.controller.ts
@@ -2,13 +2,24 @@
 import { Controller, Post, Body, Get, Query } from '@nestjs/common';
 import { VectorService } from './vector.service';
 import { SemanticRequestDto } from './dto/semantic-request.dto';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiQuery,
+  ApiBody,
+  ApiOkResponse,
+} from '@nestjs/swagger';
 
+@ApiTags('Semantic Search')
 @Controller('semantic')
 export class VectorController {
   constructor(private readonly vector: VectorService) {}
 
   // POST endpoint for semantic search on products
   @Post('products')
+  @ApiOperation({ summary: 'بحث دلالي في المنتجات' })
+  @ApiBody({ type: SemanticRequestDto })
+  @ApiOkResponse()
   async semanticSProducts(@Body() dto: SemanticRequestDto) {
     const recs = await this.vector.querySimilarProducts(
       dto.text,
@@ -19,6 +30,11 @@ export class VectorController {
   }
   // GET endpoint with optional topK parameter
   @Get('products')
+  @ApiOperation({ summary: 'بحث دلالي في المنتجات عبر النص' })
+  @ApiQuery({ name: 'text', description: 'نص البحث' })
+  @ApiQuery({ name: 'merchantId', description: 'معرف التاجر' })
+  @ApiQuery({ name: 'topK', required: false, type: Number })
+  @ApiOkResponse()
   async semanticSearchProductsByQuery(
     @Query('text') text: string,
     @Query('merchantId') merchantId: string,
@@ -35,6 +51,10 @@ export class VectorController {
 
   // GET endpoint for semantic search on offers
   @Get('offers')
+  @ApiOperation({ summary: 'بحث دلالي في العروض' })
+  @ApiQuery({ name: 'text', description: 'نص البحث' })
+  @ApiQuery({ name: 'topK', required: false, type: Number })
+  @ApiOkResponse()
   async semanticSearchOffers(
     @Query('text') text: string,
     @Query('topK') topK = '5',

--- a/src/modules/webhooks/dto/telegram-webhook.dto.ts
+++ b/src/modules/webhooks/dto/telegram-webhook.dto.ts
@@ -1,13 +1,17 @@
 // src/modules/webhooks/dto/telegram-webhook.dto.ts
 import { IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class TelegramWebhookDto {
+  @ApiProperty()
   @IsString()
   readonly messageId: string;
 
+  @ApiProperty()
   @IsString()
   readonly chatId: string;
 
+  @ApiProperty()
   @IsString()
   readonly text: string;
 


### PR DESCRIPTION
## Summary
- document analytics endpoints with Swagger
- describe n8n workflow endpoints
- add docs to documents API
- document chat links, vector search and message endpoints
- annotate data transfer objects for Swagger

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861e3eabb488322bc489487bb9544c6