### PR TITLE
Add service URL env examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,14 @@ N8N_BASIC_AUTH_PASSWORD="AnotherStrongPass"
 # N8N_HOST="0.0.0.0"
 # N8N_PORT=5678
 
+# إعدادات الاتصال بـ n8n من التطبيق
+N8N_BASE_URL="http://localhost:5678"  # عنوان n8n الذي يتصل به التطبيق
+N8N_API_KEY="your-n8n-api-key"       # مفتاح API للوصول إلى n8n
+
+# إعدادات Qdrant و خدمة توليد Embeddings
+QDRANT_URL="http://localhost:6333"        # عنوان خادم Qdrant لتخزين المتجهات
+EMBEDDING_API_URL="http://localhost:8000/embed"  # مسار خدمة إنشاء embeddings
+
 # ──────────────────────────────────────────────────────────────────────────────
 # إعدادات Webhooks و Scraper
 # نقطة Webhook لـ OpenAI (API الخاص بك)


### PR DESCRIPTION
## Summary
- add examples for `N8N_BASE_URL`, `N8N_API_KEY`, `QDRANT_URL` and `EMBEDDING_API_URL`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861e9cacb0c8322bf4c1f6feff0da89