### PR TITLE
Add userId field to merchant schema

### DIFF
--- a/src/modules/auth/auth.service.spec.ts
+++ b/src/modules/auth/auth.service.spec.ts
@@ -1,18 +1,77 @@
-import { Test, TestingModule } from '@nestjs/testing';
 import { AuthService } from './auth.service';
+import { JwtService } from '@nestjs/jwt';
+import { MailService } from '../mail/mail.service';
+import { Model, Types } from 'mongoose';
+import * as bcrypt from 'bcrypt';
 
 describe('AuthService', () => {
   let service: AuthService;
+  let userModel: any;
+  let merchantModel: any;
+  let jwtService: any;
+  let mailService: any;
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [AuthService],
-    }).compile();
-
-    service = module.get<AuthService>(AuthService);
+  beforeEach(() => {
+    userModel = {
+      findOne: jest.fn(),
+      exists: jest.fn(),
+      create: jest.fn(),
+      findByIdAndDelete: jest.fn(),
+    } as Partial<Model<any>>;
+    merchantModel = {
+      findOne: jest.fn(),
+      create: jest.fn(),
+    } as Partial<Model<any>>;
+    jwtService = { sign: jest.fn().mockReturnValue('token') } as JwtService;
+    mailService = { sendVerificationEmail: jest.fn() } as MailService;
+    service = new AuthService(
+      userModel as unknown as Model<any>,
+      merchantModel as unknown as Model<any>,
+      {} as any,
+      jwtService as JwtService,
+      mailService as MailService,
+    );
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('register stores userId in merchant', async () => {
+    (userModel.exists as jest.Mock).mockResolvedValue(null);
+    const userDoc = { _id: new Types.ObjectId(), save: jest.fn() };
+    (bcrypt.hash as unknown as jest.Mock).mockResolvedValue('hashed');
+    (userModel.create as jest.Mock).mockResolvedValue(userDoc);
+    const merchantDoc = { _id: new Types.ObjectId() };
+    (merchantModel.create as jest.Mock).mockResolvedValue(merchantDoc);
+
+    await service.register({ email: 'a@b.com', password: '123', name: 'A' });
+
+    expect(merchantModel.create).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: userDoc._id }),
+    );
+  });
+
+  it('login returns merchantId', async () => {
+    const userId = new Types.ObjectId();
+    const merchantId = new Types.ObjectId();
+    const userDoc = {
+      _id: userId,
+      password: 'hashed',
+      role: 'MERCHANT',
+      name: 'A',
+      email: 'a@b.com',
+      firstLogin: false,
+    };
+    (userModel.findOne as jest.Mock).mockResolvedValue(userDoc);
+    (bcrypt.compare as unknown as jest.Mock).mockResolvedValue(true);
+    (merchantModel.findOne as jest.Mock).mockResolvedValue({ _id: merchantId });
+
+    await service.login({ email: 'a@b.com', password: '123' });
+
+    expect(merchantModel.findOne).toHaveBeenCalledWith({ userId });
+    expect(jwtService.sign).toHaveBeenCalledWith(
+      expect.objectContaining({ merchantId }),
+    );
   });
 });

--- a/src/modules/merchants/schemas/merchant.schema.spec.ts
+++ b/src/modules/merchants/schemas/merchant.schema.spec.ts
@@ -4,4 +4,9 @@ describe('MerchantSchema', () => {
   it('should be defined', () => {
     expect(MerchantSchema).toBeDefined();
   });
+
+  it('should contain userId field', () => {
+    const path = MerchantSchema.path('userId');
+    expect(path).toBeDefined();
+  });
 });

--- a/src/modules/merchants/schemas/merchant.schema.ts
+++ b/src/modules/merchants/schemas/merchant.schema.ts
@@ -1,7 +1,7 @@
 // src/merchants/schemas/merchant.schema.ts
 
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import { Document } from 'mongoose';
+import { Document, Types } from 'mongoose';
 import { buildPromptFromMerchant } from '../utils/prompt-builder';
 
 import { QuickConfig, QuickConfigSchema } from './quick-config.schema';
@@ -21,6 +21,8 @@ export interface MerchantDocument extends Merchant, Document {
 @Schema({ timestamps: true })
 export class Merchant {
   // — Core fields —
+  @Prop({ type: Types.ObjectId, ref: 'User', required: true })
+  userId: Types.ObjectId;
   @Prop({ required: true, unique: true })
   name: string;
 


### PR DESCRIPTION
## Summary
- store the owning user on merchants with a `userId` field
- add schema and service unit tests covering this field

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862e3f7b0d48322894099dce52f59e7