### PR TITLE
Add embedding/extractor/reranker links in diagrams

### DIFF
--- a/src/arch.dot
+++ b/src/arch.dot
@@ -5,6 +5,9 @@ digraph architecture {
     subgraph cluster_containers {
         label="Docker Compose Services";
         api;
+        embedding;
+        extractor;
+        reranker;
         n8n;
         qdrant;
         mongo;
@@ -19,6 +22,9 @@ digraph architecture {
     api -> redis           [label="Bull queues / cache"];
     api -> qdrant          [label="VectorService"];
     api -> minio           [label="Documents"];
+    api -> embedding       [label="REST"];
+    api -> extractor       [label="REST"];
+    api -> reranker        [label="REST"];
     api -> n8n             [label="Workflow API"];
     api -> evolution_api   [label="Integrations"];
     n8n -> api             [label="Webhooks / HTTP"];

--- a/src/modules/chat/schema/a.md
+++ b/src/modules/chat/schema/a.md
@@ -13,6 +13,9 @@ graph TD
       APIGW --> ProductService
       APIGW --> ChatService
       APIGW --> WorkflowService
+      APIGW --> EmbeddingService
+      APIGW --> ExtractorService
+      APIGW --> RerankerService
       EventBus[(RabbitMQ/Kafka)]
       AuthService -->|publish/subscribe| EventBus
       OfferService -->|publish/subscribe| EventBus


### PR DESCRIPTION
## Summary
- expand `arch.dot` with embedding/extractor/reranker services
- show API calls to these services in the chat schema diagram

## Testing
- `npm install` *(fails: unable to reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_687fdab638e083228a5b15ba64cb3db8