### PR TITLE
Add missing Swagger docs

### DIFF
--- a/src/modules/analytics/analytics.controller.ts
+++ b/src/modules/analytics/analytics.controller.ts
@@ -10,7 +10,9 @@ import {
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
 
 import { Request } from 'express';
+import { ApiTags, ApiOperation, ApiQuery, ApiOkResponse, ApiParam } from '@nestjs/swagger';
 
+@ApiTags('Analytics')
 @UseGuards(JwtAuthGuard)
 @Controller('analytics')
 export class AnalyticsController {
@@ -26,8 +28,11 @@ export class AnalyticsController {
    *     topProducts: TopProduct[],
    *     channels: { total, breakdown }
    *   }
-   */
+  */
   @Get('overview')
+  @ApiOperation({ summary: 'Overview statistics' })
+  @ApiQuery({ name: 'period', required: false, enum: ['week', 'month', 'quarter'] })
+  @ApiOkResponse({ description: 'Overview stats' })
   async overview(
     @Req() req: Request & { user: { merchantId: string } },
     @Query('period') period: 'week' | 'month' | 'quarter' = 'week',
@@ -42,8 +47,12 @@ export class AnalyticsController {
   /**
    * GET /api/analytics/top-keywords?period=...&limit=...
    * Returns KeywordCount[]
-   */
+  */
   @Get('top-keywords')
+  @ApiOperation({ summary: 'Top keywords' })
+  @ApiQuery({ name: 'period', required: false, enum: ['week', 'month', 'quarter'] })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiOkResponse({ description: 'List of top keywords' })
   async topKeywords(
     @Req() req: Request & { user: { merchantId: string } },
     @Query('period') period: 'week' | 'month' | 'quarter' = 'week',
@@ -54,6 +63,10 @@ export class AnalyticsController {
     return kws;
   }
   @Get('messages-timeline')
+  @ApiOperation({ summary: 'Messages timeline' })
+  @ApiQuery({ name: 'period', required: false, enum: ['week', 'month', 'quarter'] })
+  @ApiQuery({ name: 'groupBy', required: false, enum: ['day', 'hour'] })
+  @ApiOkResponse({ description: 'Timeline data' })
   async messagesTimeline(
     @Req() req: Request & { user: { merchantId: string } },
     @Query('period') period: 'week' | 'month' | 'quarter' = 'week',
@@ -67,6 +80,8 @@ export class AnalyticsController {
   }
 
   @Get('products-count')
+  @ApiOperation({ summary: 'Total products count' })
+  @ApiOkResponse({ description: 'Products count' })
   async productsCount(@Req() req: Request & { user: { merchantId: string } }) {
     return {
       total: await this.analytics.getProductsCount(req.user.merchantId),
@@ -76,8 +91,12 @@ export class AnalyticsController {
   /**
    * GET /api/analytics/top-products?period=...&limit=...
    * Returns TopProduct[]
-   */
+  */
   @Get('top-products')
+  @ApiOperation({ summary: 'Top products' })
+  @ApiQuery({ name: 'period', required: false, enum: ['week', 'month', 'quarter'] })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  @ApiOkResponse({ description: 'List of top products' })
   async topProducts(
     @Req() req: Request & { user: { merchantId: string } },
     @Query('period') period: 'week' | 'month' | 'quarter' = 'week',

--- a/src/modules/documents/documents.controller.ts
+++ b/src/modules/documents/documents.controller.ts
@@ -14,13 +14,28 @@ import {
 import { FileInterceptor } from '@nestjs/platform-express';
 import { Response } from 'express';
 import { DocumentsService } from './documents.service';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiParam,
+  ApiConsumes,
+  ApiBody,
+  ApiOkResponse,
+  ApiNoContentResponse,
+} from '@nestjs/swagger';
 
+@ApiTags('Documents')
 @Controller('merchants/:merchantId/documents')
 export class DocumentsController {
   constructor(private readonly svc: DocumentsService) {}
 
   @Post()
   @UseInterceptors(FileInterceptor('file'))
+  @ApiOperation({ summary: 'Upload a document for a merchant' })
+  @ApiConsumes('multipart/form-data')
+  @ApiParam({ name: 'merchantId', description: 'Merchant ID' })
+  @ApiBody({ schema: { type: 'object', properties: { file: { type: 'string', format: 'binary' } } } })
+  @ApiOkResponse({ description: 'Upload success' })
   upload(
     @Param('merchantId') merchantId: string,
     @UploadedFile() file: Express.Multer.File & { key: string },
@@ -30,11 +45,18 @@ export class DocumentsController {
   }
 
   @Get()
+  @ApiOperation({ summary: 'List all documents for a merchant' })
+  @ApiParam({ name: 'merchantId', description: 'Merchant ID' })
+  @ApiOkResponse({ description: 'List of documents' })
   list(@Param('merchantId') merchantId: string) {
     return this.svc.list(merchantId);
   }
 
   @Get(':docId')
+  @ApiOperation({ summary: 'Download a specific document' })
+  @ApiParam({ name: 'merchantId', description: 'Merchant ID' })
+  @ApiParam({ name: 'docId', description: 'Document ID' })
+  @ApiOkResponse({ description: 'Redirect to file download' })
   async download(
     @Param('merchantId') merchantId: string,
     @Param('docId') docId: string,
@@ -47,6 +69,10 @@ export class DocumentsController {
 
   @Delete(':docId')
   @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete a document' })
+  @ApiParam({ name: 'merchantId', description: 'Merchant ID' })
+  @ApiParam({ name: 'docId', description: 'Document ID' })
+  @ApiNoContentResponse({ description: 'Deleted successfully' })
   remove(
     @Param('merchantId') merchantId: string,
     @Param('docId') docId: string,

--- a/src/modules/messaging/chat-links.controller.ts
+++ b/src/modules/messaging/chat-links.controller.ts
@@ -2,12 +2,17 @@
 import { Controller, Post, Param } from '@nestjs/common';
 import { MessageService } from './message.service';
 import { v4 as uuidv4 } from 'uuid';
+import { ApiTags, ApiOperation, ApiParam, ApiOkResponse } from '@nestjs/swagger';
 
+@ApiTags('Chat Links')
 @Controller('chat-links')
 export class ChatLinksController {
   constructor(private readonly messageService: MessageService) {}
 
   @Post(':merchantId')
+  @ApiOperation({ summary: 'Create a unique chat link' })
+  @ApiParam({ name: 'merchantId', description: 'Merchant ID' })
+  @ApiOkResponse({ description: 'Chat link created' })
   async createChatLink(@Param('merchantId') merchantId: string) {
     // توليد sessionId جديد
     const sessionId = uuidv4();

--- a/src/modules/messaging/message.controller.ts
+++ b/src/modules/messaging/message.controller.ts
@@ -21,10 +21,12 @@ import {
   ApiOperation,
   ApiParam,
   ApiQuery,
+  ApiTags,
 } from '@nestjs/swagger';
 import { Public } from 'src/common/decorators/public.decorator';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
 
+@ApiTags('Messages')
 @UseGuards(JwtAuthGuard)
 @Controller('messages')
 export class MessageController {

--- a/src/modules/n8n-workflow/n8n-workflow.controller.ts
+++ b/src/modules/n8n-workflow/n8n-workflow.controller.ts
@@ -16,7 +16,15 @@ import { UpdateWorkflowDto } from './dto/update-workflow.dto';
 import { RollbackDto } from './dto/rollback.dto';
 import { SetActiveDto } from './dto/set-active.dto';
 import { JwtAuthGuard } from 'src/common/guards/jwt-auth.guard';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiParam,
+  ApiBody,
+  ApiOkResponse,
+} from '@nestjs/swagger';
 
+@ApiTags('n8n Workflows')
 @UseGuards(JwtAuthGuard, RolesGuard)
 @Controller('n8n/workflows')
 export class N8nWorkflowController {
@@ -24,6 +32,9 @@ export class N8nWorkflowController {
 
   @Post(':merchantId')
   @Roles('ADMIN', 'MEMBER')
+  @ApiOperation({ summary: 'Create workflow for a merchant' })
+  @ApiParam({ name: 'merchantId', description: 'Merchant ID' })
+  @ApiOkResponse({ description: 'Workflow created', schema: { example: { workflowId: '123' } } })
   async createForMerchant(
     @Param('merchantId') merchantId: string,
   ): Promise<{ workflowId: string }> {
@@ -38,6 +49,8 @@ export class N8nWorkflowController {
 
   @Get(':workflowId')
   @Roles('ADMIN', 'MEMBER')
+  @ApiOperation({ summary: 'Get workflow definition' })
+  @ApiParam({ name: 'workflowId', description: 'Workflow ID' })
   async get(
     @Param('workflowId') workflowId: string,
   ): Promise<WorkflowDefinition> {
@@ -46,6 +59,10 @@ export class N8nWorkflowController {
 
   @Patch(':workflowId')
   @Roles('ADMIN')
+  @ApiOperation({ summary: 'Update workflow definition' })
+  @ApiParam({ name: 'workflowId', description: 'Workflow ID' })
+  @ApiBody({ type: UpdateWorkflowDto })
+  @ApiOkResponse({ description: 'Workflow updated' })
   async update(
     @Param('workflowId') workflowId: string,
     @Body() body: UpdateWorkflowDto,
@@ -64,6 +81,10 @@ export class N8nWorkflowController {
 
   @Post(':workflowId/rollback')
   @Roles('ADMIN')
+  @ApiOperation({ summary: 'Rollback workflow to a previous version' })
+  @ApiParam({ name: 'workflowId', description: 'Workflow ID' })
+  @ApiBody({ type: RollbackDto })
+  @ApiOkResponse({ description: 'Rollback successful' })
   async rollback(
     @Param('workflowId') workflowId: string,
     @Body() dto: RollbackDto,
@@ -74,6 +95,10 @@ export class N8nWorkflowController {
 
   @Post(':workflowId/clone/:targetMerchantId')
   @Roles('ADMIN')
+  @ApiOperation({ summary: 'Clone workflow to another merchant' })
+  @ApiParam({ name: 'workflowId', description: 'Source workflow ID' })
+  @ApiParam({ name: 'targetMerchantId', description: 'Target merchant ID' })
+  @ApiOkResponse({ description: 'Cloned successfully' })
   async clone(
     @Param('workflowId') sourceId: string,
     @Param('targetMerchantId') targetMerchantId: string,
@@ -88,6 +113,10 @@ export class N8nWorkflowController {
 
   @Patch(':workflowId/active')
   @Roles('ADMIN')
+  @ApiOperation({ summary: 'Activate or deactivate workflow' })
+  @ApiParam({ name: 'workflowId', description: 'Workflow ID' })
+  @ApiBody({ type: SetActiveDto })
+  @ApiOkResponse({ description: 'Status updated' })
   async setActive(
     @Param('workflowId') workflowId: string,
     @Body() dto: SetActiveDto,

--- a/src/modules/orders/orders.controller.ts
+++ b/src/modules/orders/orders.controller.ts
@@ -2,30 +2,51 @@
 import { Controller, Post, Body, Get, Param, Patch } from '@nestjs/common';
 import { OrdersService } from './orders.service';
 import { CreateOrderDto } from './dto/create-order.dto';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiBody,
+  ApiParam,
+  ApiOkResponse,
+  ApiCreatedResponse,
+} from '@nestjs/swagger';
 
+@ApiTags('Orders')
 @Controller('orders')
 export class OrdersController {
   constructor(private readonly ordersService: OrdersService) {}
 
   @Post()
+  @ApiOperation({ summary: 'Create a new order' })
+  @ApiBody({ type: CreateOrderDto })
+  @ApiCreatedResponse({ description: 'Order created' })
   async create(@Body() dto: CreateOrderDto) {
     return this.ordersService.create(dto);
   }
 
   // جلب جميع الطلبات
   @Get()
+  @ApiOperation({ summary: 'Get all orders' })
+  @ApiOkResponse({ description: 'List of orders' })
   async findAll() {
     return this.ordersService.findAll();
   }
 
   // جلب طلب محدد بالتفصيل
   @Get(':id')
+  @ApiOperation({ summary: 'Get one order by ID' })
+  @ApiParam({ name: 'id', description: 'Order ID' })
+  @ApiOkResponse({ description: 'Order details' })
   async findOne(@Param('id') id: string) {
     return this.ordersService.findOne(id);
   }
 
   // تعديل حالة الطلب (مثال: pending/paid/canceled)
   @Patch(':id/status')
+  @ApiOperation({ summary: 'Update order status' })
+  @ApiParam({ name: 'id', description: 'Order ID' })
+  @ApiBody({ schema: { type: 'object', properties: { status: { type: 'string' } } } })
+  @ApiOkResponse({ description: 'Status updated' })
   async updateStatus(@Param('id') id: string, @Body('status') status: string) {
     return this.ordersService.updateStatus(id, status);
   }

--- a/src/modules/storefront/storefront.controller.ts
+++ b/src/modules/storefront/storefront.controller.ts
@@ -1,13 +1,18 @@
 // src/storefront/storefront.controller.ts
 import { Controller, Get, Param } from '@nestjs/common';
 import { StorefrontService } from './storefront.service';
+import { ApiTags, ApiOperation, ApiParam, ApiOkResponse } from '@nestjs/swagger';
 
+@ApiTags('Storefront')
 @Controller('store')
 export class StorefrontController {
   constructor(private svc: StorefrontService) {}
 
   /** GET /api/store/:slugOrId */
   @Get(':slugOrId')
+  @ApiOperation({ summary: 'Get storefront by slug or merchantId' })
+  @ApiParam({ name: 'slugOrId', description: 'Merchant slug or ID' })
+  @ApiOkResponse({ description: 'Storefront data' })
   async storefront(@Param('slugOrId') slugOrId: string) {
     return this.svc.getStorefront(slugOrId);
   }

--- a/src/modules/vector/vector.controller.ts
+++ b/src/modules/vector/vector.controller.ts
@@ -4,7 +4,15 @@ import { VectorService } from './vector.service';
 import { SemanticRequestDto } from './dto/semantic-request.dto';
 import { Public } from 'src/common/decorators/public.decorator';
 import { JwtAuthGuard } from 'src/common/guards/jwt-auth.guard';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiBody,
+  ApiQuery,
+  ApiOkResponse,
+} from '@nestjs/swagger';
 
+@ApiTags('Semantic Search')
 @Controller('semantic')
 @UseGuards(JwtAuthGuard)
 export class VectorController {
@@ -13,6 +21,9 @@ export class VectorController {
   // POST endpoint for semantic search on products
   @Post('products')
   @Public()
+  @ApiOperation({ summary: 'Semantic search for products (POST body)' })
+  @ApiBody({ type: SemanticRequestDto })
+  @ApiOkResponse({ description: 'Recommended products' })
   async semanticSProducts(@Body() dto: SemanticRequestDto) {
     const recs = await this.vector.querySimilarProducts(
       dto.text,
@@ -24,6 +35,11 @@ export class VectorController {
   // GET endpoint with optional topK parameter
   @Get('products')
   @Public()
+  @ApiOperation({ summary: 'Semantic search for products via query' })
+  @ApiQuery({ name: 'text' })
+  @ApiQuery({ name: 'merchantId' })
+  @ApiQuery({ name: 'topK', required: false, type: Number })
+  @ApiOkResponse({ description: 'Recommended products' })
   async semanticSearchProductsByQuery(
     @Query('text') text: string,
     @Query('merchantId') merchantId: string,

--- a/src/modules/webhooks/webhooks.controller.ts
+++ b/src/modules/webhooks/webhooks.controller.ts
@@ -13,13 +13,18 @@ import { MessageService } from '../messaging/message.service';
 import { CreateMessageDto } from '../messaging/dto/create-message.dto';
 import { Public } from 'src/common/decorators/public.decorator';
 import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
+import { ApiTags, ApiOperation, ApiParam, ApiOkResponse } from '@nestjs/swagger';
 
+@ApiTags('Webhooks')
 @UseGuards(JwtAuthGuard)
 @Controller('webhooks')
 export class WebhooksController {
   constructor(private readonly messageService: MessageService) {}
   @Public()
   @Post('incoming/:merchantId')
+  @ApiOperation({ summary: 'Handle incoming message' })
+  @ApiParam({ name: 'merchantId', description: 'Merchant ID' })
+  @ApiOkResponse({ description: 'Session updated' })
   async handleIncoming(
     @Param('merchantId') merchantId: string,
     @Body() body: any,
@@ -58,6 +63,9 @@ export class WebhooksController {
 
   @Public()
   @Post('bot-reply/:merchantId')
+  @ApiOperation({ summary: 'Handle bot reply message' })
+  @ApiParam({ name: 'merchantId', description: 'Merchant ID' })
+  @ApiOkResponse({ description: 'Session updated' })
   async handleBotReply(
     @Param('merchantId') merchantId: string,
     @Body() body: any,


### PR DESCRIPTION
## Summary
- add Swagger annotations for storefront API
- document semantic search endpoints
- document document management routes
- document n8n workflow endpoints
- document order API
- document chat link API
- add tags for messages, analytics and webhooks controllers

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: nest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fe3f302b8832296a0fd9ce95c3ce2