### PR TITLE
Add comprehensive unit tests

### DIFF
--- a/src/modules/users/users.service.spec.ts
+++ b/src/modules/users/users.service.spec.ts
@@ -1,12 +1,57 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import { Types } from 'mongoose';
+import { NotFoundException } from '@nestjs/common';
 import { UsersService } from './users.service';
+import { User } from './schemas/user.schema';
 
 describe('UsersService', () => {
   let service: UsersService;
+  let model: any;
+
+  const userId = new Types.ObjectId().toHexString();
+  const baseUser = {
+    _id: userId,
+    email: 'user@example.com',
+    name: 'Test User',
+    merchantId: null,
+    firstLogin: true,
+    role: 'ADMIN',
+    phone: '+1234567890',
+  };
 
   beforeEach(async () => {
+    const mockModel: any = jest.fn().mockImplementation((dto) => ({
+      ...dto,
+      save: jest.fn().mockResolvedValue({ _id: userId, ...dto }),
+    }));
+
+    mockModel.find = jest.fn().mockReturnValue({
+      exec: jest.fn().mockResolvedValue([baseUser]),
+    });
+
+    mockModel.findById = jest.fn().mockReturnValue({
+      lean: jest.fn().mockResolvedValue(baseUser),
+    });
+
+    mockModel.findByIdAndUpdate = jest
+      .fn()
+      .mockResolvedValue({ ...baseUser, name: 'Updated' });
+
+    mockModel.findByIdAndDelete = jest.fn().mockReturnValue({
+      exec: jest.fn().mockResolvedValue(baseUser),
+    });
+
+    model = mockModel;
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [UsersService],
+      providers: [
+        UsersService,
+        {
+          provide: getModelToken(User.name),
+          useValue: model,
+        },
+      ],
     }).compile();
 
     service = module.get<UsersService>(UsersService);
@@ -14,5 +59,82 @@ describe('UsersService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('creates a user', async () => {
+    const dto = {
+      email: 'user@example.com',
+      name: 'Test User',
+      merchantId: null,
+      firstLogin: true,
+      role: 'ADMIN',
+      phone: '+1234567890',
+    };
+    const result = await service.create(dto as any);
+    expect(model).toHaveBeenCalledWith(dto);
+    expect(result).toEqual({ _id: userId, ...dto });
+  });
+
+  it('finds all users', async () => {
+    const users = await service.findAll();
+    expect(model.find).toHaveBeenCalled();
+    expect(users).toEqual([baseUser]);
+  });
+
+  it('finds one user', async () => {
+    const user = await service.findOne(userId);
+    expect(model.findById).toHaveBeenCalledWith(userId);
+    expect(user.id).toEqual(userId);
+  });
+
+  it('throws if user not found', async () => {
+    (model.findById as jest.Mock).mockReturnValueOnce({
+      lean: jest.fn().mockResolvedValue(null),
+    });
+    await expect(service.findOne('bad')).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+  });
+
+  it('updates a user', async () => {
+    const result = await service.update(userId, { name: 'Updated' } as any);
+    expect(model.findByIdAndUpdate).toHaveBeenCalled();
+    expect(result.name).toBe('Updated');
+  });
+
+  it('throws when updating nonexistent user', async () => {
+    (model.findByIdAndUpdate as jest.Mock).mockResolvedValueOnce(null);
+    await expect(service.update('bad', {} as any)).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+  });
+
+  it('removes a user', async () => {
+    const result = await service.remove(userId);
+    expect(model.findByIdAndDelete).toHaveBeenCalledWith(userId);
+    expect(result).toEqual({ message: 'User deleted successfully' });
+  });
+
+  it('throws when removing nonexistent user', async () => {
+    (model.findByIdAndDelete as jest.Mock).mockReturnValueOnce({
+      exec: jest.fn().mockResolvedValue(null),
+    });
+    await expect(service.remove('bad')).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('sets firstLogin to false', async () => {
+    await service.setFirstLoginFalse(userId);
+    expect(model.findByIdAndUpdate).toHaveBeenCalledWith(
+      userId,
+      { firstLogin: false },
+      { new: true },
+    );
+  });
+
+  it('throws when setFirstLoginFalse fails', async () => {
+    (model.findByIdAndUpdate as jest.Mock).mockResolvedValueOnce(null);
+    await expect(service.setFirstLoginFalse('bad')).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
   });
 });

--- a/src/modules/vector/vector.service.spec.ts
+++ b/src/modules/vector/vector.service.spec.ts
@@ -1,0 +1,21 @@
+import { VectorService } from './vector.service';
+import { HttpService } from '@nestjs/axios';
+import { ProductsService } from '../products/products.service';
+
+describe('VectorService', () => {
+  it('builds embedding text correctly', () => {
+    const service = new VectorService({} as HttpService, {} as ProductsService);
+    const text = (service as any).buildTextForEmbedding({
+      id: '1',
+      name: 'Phone',
+      description: 'Nice phone',
+      category: 'Electronics',
+      specsBlock: ['64GB', 'Black'],
+      keywords: ['smartphone', 'mobile'],
+      merchantId: 'm1',
+    });
+    expect(text).toBe(
+      'Name: Phone. Description: Nice phone. Category: Electronics. Specs: 64GB, Black. Keywords: smartphone, mobile',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- expand `users.service` tests with mongoose model mocking
- add test for VectorService `buildTextForEmbedding`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fe6cb59f08322b15bf16c085f0a24