### PR TITLE
Add minimal tests for all services

### DIFF
--- a/src/modules/analytics/analytics.service.spec.ts
+++ b/src/modules/analytics/analytics.service.spec.ts
@@ -1,0 +1,26 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AnalyticsService } from './analytics.service';
+
+describe('AnalyticsService', () => {
+  let service: AnalyticsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AnalyticsService],
+    }).compile();
+
+    service = module.get<AnalyticsService>(AnalyticsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('calculates week period', () => {
+    const { start, end } = (service as any).getPeriodDates('week');
+    expect(end.getTime()).toBeGreaterThan(start.getTime());
+    const diff = end.getTime() - start.getTime();
+    expect(diff).toBeGreaterThan(6 * 24 * 60 * 60 * 1000);
+    expect(diff).toBeLessThan(8 * 24 * 60 * 60 * 1000);
+  });
+});

--- a/src/modules/categories/categories.service.spec.ts
+++ b/src/modules/categories/categories.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CategoriesService } from './categories.service';
+
+describe('CategoriesService', () => {
+  let service: CategoriesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CategoriesService],
+    }).compile();
+
+    service = module.get<CategoriesService>(CategoriesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/chat/chat-widget.service.spec.ts
+++ b/src/modules/chat/chat-widget.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ChatWidgetService } from './chat-widget.service';
+
+describe('ChatWidgetService', () => {
+  let service: ChatWidgetService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ChatWidgetService],
+    }).compile();
+
+    service = module.get<ChatWidgetService>(ChatWidgetService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/documents/documents.service.spec.ts
+++ b/src/modules/documents/documents.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DocumentsService } from './documents.service';
+
+describe('DocumentsService', () => {
+  let service: DocumentsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [DocumentsService],
+    }).compile();
+
+    service = module.get<DocumentsService>(DocumentsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/extract/extract.service.spec.ts
+++ b/src/modules/extract/extract.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExtractService } from './extract.service';
+
+describe('ExtractService', () => {
+  let service: ExtractService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ExtractService],
+    }).compile();
+
+    service = module.get<ExtractService>(ExtractService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/integrations/evolution.service.spec.ts
+++ b/src/modules/integrations/evolution.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EvolutionService } from './evolution.service';
+
+describe('EvolutionService', () => {
+  let service: EvolutionService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [EvolutionService],
+    }).compile();
+
+    service = module.get<EvolutionService>(EvolutionService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/integrations/integrations.service.spec.ts
+++ b/src/modules/integrations/integrations.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { IntegrationsService } from './integrations.service';
+
+describe('IntegrationsService', () => {
+  let service: IntegrationsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [IntegrationsService],
+    }).compile();
+
+    service = module.get<IntegrationsService>(IntegrationsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/leads/leads.service.spec.ts
+++ b/src/modules/leads/leads.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LeadsService } from './leads.service';
+
+describe('LeadsService', () => {
+  let service: LeadsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [LeadsService],
+    }).compile();
+
+    service = module.get<LeadsService>(LeadsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/mail/mail.service.spec.ts
+++ b/src/modules/mail/mail.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MailService } from './mail.service';
+
+describe('MailService', () => {
+  let service: MailService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MailService],
+    }).compile();
+
+    service = module.get<MailService>(MailService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/merchants/merchant-checklist.service.spec.ts
+++ b/src/modules/merchants/merchant-checklist.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MerchantChecklistService } from './merchant-checklist.service';
+
+describe('MerchantChecklistService', () => {
+  let service: MerchantChecklistService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MerchantChecklistService],
+    }).compile();
+
+    service = module.get<MerchantChecklistService>(MerchantChecklistService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/merchants/services/prompt-builder.service.spec.ts
+++ b/src/modules/merchants/services/prompt-builder.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PromptBuilderService } from './prompt-builder.service';
+
+describe('PromptBuilderService', () => {
+  let service: PromptBuilderService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PromptBuilderService],
+    }).compile();
+
+    service = module.get<PromptBuilderService>(PromptBuilderService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/merchants/services/prompt-preview.service.spec.ts
+++ b/src/modules/merchants/services/prompt-preview.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PromptPreviewService } from './prompt-preview.service';
+
+describe('PromptPreviewService', () => {
+  let service: PromptPreviewService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PromptPreviewService],
+    }).compile();
+
+    service = module.get<PromptPreviewService>(PromptPreviewService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/merchants/services/prompt-version.service.spec.ts
+++ b/src/modules/merchants/services/prompt-version.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PromptVersionService } from './prompt-version.service';
+
+describe('PromptVersionService', () => {
+  let service: PromptVersionService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PromptVersionService],
+    }).compile();
+
+    service = module.get<PromptVersionService>(PromptVersionService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/messaging/message.service.spec.ts
+++ b/src/modules/messaging/message.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MessageService } from './message.service';
+
+describe('MessageService', () => {
+  let service: MessageService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MessageService],
+    }).compile();
+
+    service = module.get<MessageService>(MessageService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/n8n-workflow/n8n-workflow.service.spec.ts
+++ b/src/modules/n8n-workflow/n8n-workflow.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { N8nWorkflowService } from './n8n-workflow.service';
+
+describe('N8nWorkflowService', () => {
+  let service: N8nWorkflowService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [N8nWorkflowService],
+    }).compile();
+
+    service = module.get<N8nWorkflowService>(N8nWorkflowService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/orders/orders.service.spec.ts
+++ b/src/modules/orders/orders.service.spec.ts
@@ -1,0 +1,65 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import { OrdersService } from './orders.service';
+import { Order } from './schemas/order.schema';
+import { LeadsService } from '../leads/leads.service';
+
+describe('OrdersService', () => {
+  let service: OrdersService;
+  let orderModel: any;
+  let leads: any;
+
+  beforeEach(async () => {
+    orderModel = {
+      create: jest.fn().mockResolvedValue({ toObject: jest.fn().mockReturnValue({ id: '1' }) }),
+      find: jest.fn().mockReturnValue({ sort: jest.fn().mockReturnValue({ exec: jest.fn().mockResolvedValue(['o']) }) }),
+      findById: jest.fn().mockReturnValue({ populate: jest.fn().mockReturnValue({ exec: jest.fn().mockResolvedValue('o') }) }),
+      findByIdAndUpdate: jest.fn().mockResolvedValue({ id: '1', status: 'done' }),
+    };
+    leads = { create: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OrdersService,
+        { provide: getModelToken(Order.name), useValue: orderModel },
+        { provide: LeadsService, useValue: leads },
+      ],
+    }).compile();
+
+    service = module.get<OrdersService>(OrdersService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('creates an order and records lead', async () => {
+    const dto: any = { merchantId: 'm1', sessionId: 's', customer: {} };
+    const order = await service.create(dto);
+    expect(orderModel.create).toHaveBeenCalledWith(dto);
+    expect(leads.create).toHaveBeenCalledWith('m1', {
+      sessionId: 's',
+      data: {},
+      source: 'order',
+    });
+    expect(order).toEqual({ id: '1' });
+  });
+
+  it('finds all orders', async () => {
+    const res = await service.findAll();
+    expect(orderModel.find).toHaveBeenCalled();
+    expect(res).toEqual(['o']);
+  });
+
+  it('finds one order', async () => {
+    const res = await service.findOne('1');
+    expect(orderModel.findById).toHaveBeenCalledWith('1');
+    expect(res).toBe('o');
+  });
+
+  it('updates status', async () => {
+    const res = await service.updateStatus('1', 'done');
+    expect(orderModel.findByIdAndUpdate).toHaveBeenCalledWith('1', { status: 'done' }, { new: true });
+    expect(res.status).toBe('done');
+  });
+});

--- a/src/modules/products/product-setup-config.service.spec.ts
+++ b/src/modules/products/product-setup-config.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProductSetupConfigService } from './product-setup-config.service';
+
+describe('ProductSetupConfigService', () => {
+  let service: ProductSetupConfigService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ProductSetupConfigService],
+    }).compile();
+
+    service = module.get<ProductSetupConfigService>(ProductSetupConfigService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/products/products-import.service.spec.ts
+++ b/src/modules/products/products-import.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProductsImportService } from './products-import.service';
+
+describe('ProductsImportService', () => {
+  let service: ProductsImportService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ProductsImportService],
+    }).compile();
+
+    service = module.get<ProductsImportService>(ProductsImportService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/storefront/storefront.service.spec.ts
+++ b/src/modules/storefront/storefront.service.spec.ts
@@ -1,0 +1,39 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import { StorefrontService } from './storefront.service';
+import { Merchant } from '../merchants/schemas/merchant.schema';
+import { Product } from '../products/schemas/product.schema';
+import { Category } from '../categories/schemas/category.schema';
+import { NotFoundException } from '@nestjs/common';
+
+describe('StorefrontService', () => {
+  let service: StorefrontService;
+  let merchantModel: any;
+  let productModel: any;
+  let categoryModel: any;
+
+  beforeEach(async () => {
+    merchantModel = { findOne: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(null) }) };
+    productModel = { find: jest.fn().mockReturnValue({ sort: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([]) }) }) };
+    categoryModel = { find: jest.fn().mockReturnValue({ sort: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([]) }) }) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StorefrontService,
+        { provide: getModelToken(Merchant.name), useValue: merchantModel },
+        { provide: getModelToken(Product.name), useValue: productModel },
+        { provide: getModelToken(Category.name), useValue: categoryModel },
+      ],
+    }).compile();
+
+    service = module.get<StorefrontService>(StorefrontService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('throws when merchant not found', async () => {
+    await expect(service.getStorefront('bad')).rejects.toBeInstanceOf(NotFoundException);
+  });
+});

--- a/src/modules/users/users.service.spec.ts
+++ b/src/modules/users/users.service.spec.ts
@@ -1,12 +1,57 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { getModelToken } from '@nestjs/mongoose';
+import { Types } from 'mongoose';
+import { NotFoundException } from '@nestjs/common';
 import { UsersService } from './users.service';
+import { User } from './schemas/user.schema';
 
 describe('UsersService', () => {
   let service: UsersService;
+  let model: any;
+
+  const userId = new Types.ObjectId().toHexString();
+  const baseUser = {
+    _id: userId,
+    email: 'user@example.com',
+    name: 'Test User',
+    merchantId: null,
+    firstLogin: true,
+    role: 'ADMIN',
+    phone: '+1234567890',
+  };
 
   beforeEach(async () => {
+    const mockModel: any = jest.fn().mockImplementation((dto) => ({
+      ...dto,
+      save: jest.fn().mockResolvedValue({ _id: userId, ...dto }),
+    }));
+
+    mockModel.find = jest.fn().mockReturnValue({
+      exec: jest.fn().mockResolvedValue([baseUser]),
+    });
+
+    mockModel.findById = jest.fn().mockReturnValue({
+      lean: jest.fn().mockResolvedValue(baseUser),
+    });
+
+    mockModel.findByIdAndUpdate = jest
+      .fn()
+      .mockResolvedValue({ ...baseUser, name: 'Updated' });
+
+    mockModel.findByIdAndDelete = jest.fn().mockReturnValue({
+      exec: jest.fn().mockResolvedValue(baseUser),
+    });
+
+    model = mockModel;
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [UsersService],
+      providers: [
+        UsersService,
+        {
+          provide: getModelToken(User.name),
+          useValue: model,
+        },
+      ],
     }).compile();
 
     service = module.get<UsersService>(UsersService);
@@ -14,5 +59,82 @@ describe('UsersService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('creates a user', async () => {
+    const dto = {
+      email: 'user@example.com',
+      name: 'Test User',
+      merchantId: null,
+      firstLogin: true,
+      role: 'ADMIN',
+      phone: '+1234567890',
+    };
+    const result = await service.create(dto as any);
+    expect(model).toHaveBeenCalledWith(dto);
+    expect(result).toEqual({ _id: userId, ...dto });
+  });
+
+  it('finds all users', async () => {
+    const users = await service.findAll();
+    expect(model.find).toHaveBeenCalled();
+    expect(users).toEqual([baseUser]);
+  });
+
+  it('finds one user', async () => {
+    const user = await service.findOne(userId);
+    expect(model.findById).toHaveBeenCalledWith(userId);
+    expect(user.id).toEqual(userId);
+  });
+
+  it('throws if user not found', async () => {
+    (model.findById as jest.Mock).mockReturnValueOnce({
+      lean: jest.fn().mockResolvedValue(null),
+    });
+    await expect(service.findOne('bad')).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+  });
+
+  it('updates a user', async () => {
+    const result = await service.update(userId, { name: 'Updated' } as any);
+    expect(model.findByIdAndUpdate).toHaveBeenCalled();
+    expect(result.name).toBe('Updated');
+  });
+
+  it('throws when updating nonexistent user', async () => {
+    (model.findByIdAndUpdate as jest.Mock).mockResolvedValueOnce(null);
+    await expect(service.update('bad', {} as any)).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+  });
+
+  it('removes a user', async () => {
+    const result = await service.remove(userId);
+    expect(model.findByIdAndDelete).toHaveBeenCalledWith(userId);
+    expect(result).toEqual({ message: 'User deleted successfully' });
+  });
+
+  it('throws when removing nonexistent user', async () => {
+    (model.findByIdAndDelete as jest.Mock).mockReturnValueOnce({
+      exec: jest.fn().mockResolvedValue(null),
+    });
+    await expect(service.remove('bad')).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('sets firstLogin to false', async () => {
+    await service.setFirstLoginFalse(userId);
+    expect(model.findByIdAndUpdate).toHaveBeenCalledWith(
+      userId,
+      { firstLogin: false },
+      { new: true },
+    );
+  });
+
+  it('throws when setFirstLoginFalse fails', async () => {
+    (model.findByIdAndUpdate as jest.Mock).mockResolvedValueOnce(null);
+    await expect(service.setFirstLoginFalse('bad')).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
   });
 });

--- a/src/modules/vector/vector.service.spec.ts
+++ b/src/modules/vector/vector.service.spec.ts
@@ -1,0 +1,21 @@
+import { VectorService } from './vector.service';
+import { HttpService } from '@nestjs/axios';
+import { ProductsService } from '../products/products.service';
+
+describe('VectorService', () => {
+  it('builds embedding text correctly', () => {
+    const service = new VectorService({} as HttpService, {} as ProductsService);
+    const text = (service as any).buildTextForEmbedding({
+      id: '1',
+      name: 'Phone',
+      description: 'Nice phone',
+      category: 'Electronics',
+      specsBlock: ['64GB', 'Black'],
+      keywords: ['smartphone', 'mobile'],
+      merchantId: 'm1',
+    });
+    expect(text).toBe(
+      'Name: Phone. Description: Nice phone. Category: Electronics. Specs: 64GB, Black. Keywords: smartphone, mobile',
+    );
+  });
+});

--- a/src/modules/workflow-history/workflow-history.service.spec.ts
+++ b/src/modules/workflow-history/workflow-history.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WorkflowHistoryService } from './workflow-history.service';
+
+describe('WorkflowHistoryService', () => {
+  let service: WorkflowHistoryService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [WorkflowHistoryService],
+    }).compile();
+
+    service = module.get<WorkflowHistoryService>(WorkflowHistoryService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add missing spec files for multiple services with basic instantiation tests
- implement functional tests for `OrdersService`, `AnalyticsService`, and `StorefrontService`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fe6cb59f08322b15bf16c085f0a24