### PR TITLE
chore: add swagger generation utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "seed:admin": "ts-node -r tsconfig-paths/register src/scripts/seed-admin.ts",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "generate-swagger": "ts-node -r tsconfig-paths/register scripts/generate-swagger.ts"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",

--- a/scripts/generate-swagger.ts
+++ b/scripts/generate-swagger.ts
@@ -1,0 +1,38 @@
+import { NestFactory } from '@nestjs/core';
+import { SwaggerModule } from '@nestjs/swagger';
+import { writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+
+import { AppModule } from '../src/app.module';
+import { buildSwaggerConfig } from '../src/config/swagger.config';
+
+async function generateSwagger() {
+  // Provide default environment variables to satisfy module initialization
+  process.env.MONGODB_URI ||= 'mongodb://localhost:27017/test';
+  process.env.REDIS_URL ||= 'redis://localhost:6379';
+  process.env.MINIO_ENDPOINT ||= 'localhost';
+  process.env.MINIO_PORT ||= '9000';
+  process.env.MINIO_USE_SSL ||= 'false';
+  process.env.MINIO_ACCESS_KEY ||= 'dummy';
+  process.env.MINIO_SECRET_KEY ||= 'dummy';
+  process.env.JWT_SECRET ||= 'secret';
+  process.env.MAIL_HOST ||= 'localhost';
+  process.env.MAIL_PORT ||= '1025';
+  process.env.MAIL_USER ||= 'user';
+  process.env.MAIL_PASS ||= 'pass';
+  process.env.MAIL_FROM ||= 'test@example.com';
+
+  const app = await NestFactory.create(AppModule);
+  const config = buildSwaggerConfig();
+  const document = SwaggerModule.createDocument(app, config, {
+    deepScanRoutes: true,
+  });
+
+  const outputPath = join(process.cwd(), 'docs');
+  mkdirSync(outputPath, { recursive: true });
+  writeFileSync(join(outputPath, 'swagger.json'), JSON.stringify(document, null, 2));
+
+  await app.close();
+}
+
+void generateSwagger();

--- a/src/config/swagger.config.ts
+++ b/src/config/swagger.config.ts
@@ -1,0 +1,24 @@
+import { DocumentBuilder } from '@nestjs/swagger';
+
+export function buildSwaggerConfig() {
+  return new DocumentBuilder()
+    .setTitle('MusaidBot API')
+    .setDescription('API documentation for MusaidBot')
+    .setVersion('1.0')
+    .addBearerAuth(
+      {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+        name: 'Authorization',
+        description: 'Enter JWT token',
+        in: 'header',
+      },
+      'access-token',
+    )
+    .setContact('Smart Academy', 'https://smartacademy.sa', 'support@smartacademy.sa')
+    .setLicense('MIT', 'https://opensource.org/licenses/MIT')
+    .addServer('http://localhost:5000', 'Local environment')
+    .addServer('https://api.musaidbot.com', 'Production')
+    .build();
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import { NestFactory } from '@nestjs/core';
 import { RequestMethod, ValidationPipe } from '@nestjs/common';
 import helmet from 'helmet';
 import rateLimit from 'express-rate-limit';
-import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
+import { SwaggerModule } from '@nestjs/swagger';
 import { Logger as PinoLogger } from 'nestjs-pino';
 import { randomUUID } from 'crypto';
 import { IoAdapter } from '@nestjs/platform-socket.io';
@@ -13,6 +13,7 @@ import { AppModule } from './app.module';
 import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { HttpMetricsInterceptor } from './common/interceptors/http-metrics.interceptor';
+import { buildSwaggerConfig } from './config/swagger.config';
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
@@ -58,30 +59,7 @@ async function bootstrap() {
     app.get(HttpMetricsInterceptor),
   );
 
-  const config = new DocumentBuilder()
-    .setTitle('MusaidBot API')
-    .setDescription('API documentation for MusaidBot')
-    .setVersion('1.0')
-    .addBearerAuth(
-      {
-        type: 'http',
-        scheme: 'bearer',
-        bearerFormat: 'JWT',
-        name: 'Authorization',
-        description: 'Enter JWT token',
-        in: 'header',
-      },
-      'access-token',
-    )
-    .setContact(
-      'Smart Academy',
-      'https://smartacademy.sa',
-      'support@smartacademy.sa',
-    )
-    .setLicense('MIT', 'https://opensource.org/licenses/MIT')
-    .addServer('http://localhost:5000', 'Local environment')
-    .addServer('https://api.musaidbot.com', 'Production')
-    .build();
+  const config = buildSwaggerConfig();
   const document = SwaggerModule.createDocument(app, config, {
     deepScanRoutes: true, // يضمن اكتشاف جميع المسارات
   });

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,7 +28,6 @@ async function bootstrap() {
     (globalThis as any).crypto = { randomUUID };
   }
   app.useWebSocketAdapter(new IoAdapter(app));
-  console.log('REDIS_URL:', process.env.REDIS_URL);
 
   app.use(helmet());
   app.enableCors({

--- a/src/modules/storefront/storefront.controller.ts
+++ b/src/modules/storefront/storefront.controller.ts
@@ -13,6 +13,9 @@ import { Public } from 'src/common/decorators/public.decorator';
 import { JwtAuthGuard } from 'src/common/guards/jwt-auth.guard';
 import { UpdateStorefrontDto } from './dto/update-storefront.dto';
 import { CreateStorefrontDto } from './dto/create-storefront.dto';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+@ApiTags('Storefront')
+@ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
 @Controller('store')
 export class StorefrontController {


### PR DESCRIPTION
## Summary
- centralize Swagger configuration for reuse
- add script to output Swagger spec with default env values
- annotate Storefront controller with Swagger tags and auth info

## Testing
- `npm run generate-swagger` *(fails: Missing email configuration/DB connection)*
- `npm test -- --config jest.config.js` *(fails: module <rootDir>/../test/setup.ts not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fc436c1a083229b1213cf3db0438b